### PR TITLE
Hexadecimal number support

### DIFF
--- a/syntax/json5.vim
+++ b/syntax/json5.vim
@@ -4,10 +4,10 @@ if exists('b:current_syntax') && b:current_syntax == 'json5'
 endif
 
 " Syntax: Numbers {{{1
-syn match   json5Number    "[-+]\=\%(0\|[1-9]\d*\)\%(\.\d*\)\=\%([eE][-+]\=\d\+\)\="
-syn match   json5Number    "[-+]\=\%(\.\d\+\)\%([eE][-+]\=\d\+\)\="
-syn match   json5Number    "[-+]\=0[xX]\x*"
-syn keyword json5Number    Infinity -Infinity NaN
+syn match json5Number    "[-+]\=\%(0\|[1-9]\d*\)\%(\.\d*\)\=\%([eE][-+]\=\d\+\)\="
+syn match json5Number    "[-+]\=\%(\.\d\+\)\%([eE][-+]\=\d\+\)\="
+syn match json5Number    "[-+]\=0[xX]\x*"
+syn match json5Number    "[-+]\=Infinity\|NaN"
 
 " Syntax: An integer part of 0 followed by other digits is not allowed.
 syn match   json5NumError  "-\=\<0\d\.\d*\>"

--- a/syntax/json5.vim
+++ b/syntax/json5.vim
@@ -3,6 +3,15 @@ if exists('b:current_syntax') && b:current_syntax == 'json5'
   finish
 endif
 
+" Syntax: Numbers {{{1
+syn match   json5Number    "[-+]\=\%(0\|[1-9]\d*\)\%(\.\d*\)\=\%([eE][-+]\=\d\+\)\="
+syn match   json5Number    "[-+]\=\%(\.\d\+\)\%([eE][-+]\=\d\+\)\="
+syn match   json5Number    "[-+]\=0[xX]\x*"
+syn keyword json5Number    Infinity -Infinity NaN
+
+" Syntax: An integer part of 0 followed by other digits is not allowed.
+syn match   json5NumError  "-\=\<0\d\.\d*\>"
+
 " Syntax: Strings {{{1
 syn region  json5String    start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=json5Escape
 syn region  json5String    start=+'+  skip=+\\\\\|\\'+  end=+'+  contains=json5Escape
@@ -10,14 +19,6 @@ syn region  json5String    start=+'+  skip=+\\\\\|\\'+  end=+'+  contains=json5E
 " Syntax: Escape sequences
 syn match   json5Escape    "\\["\\/bfnrt]" contained
 syn match   json5Escape    "\\u\x\{4}" contained
-
-" Syntax: Numbers {{{1
-syn match   json5Number    "[-+]\=\.\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>"
-syn match   json5Number    "[-+]\=0[xX]\x*"
-syn keyword json5Number    Infinity -Infinity NaN
-
-" Syntax: An integer part of 0 followed by other digits is not allowed.
-syn match   json5NumError  "-\=\<0\d\.\d*\>"
 
 " Syntax: Boolean {{{1
 syn keyword json5Boolean   true false

--- a/syntax/json5.vim
+++ b/syntax/json5.vim
@@ -12,8 +12,9 @@ syn match   json5Escape    "\\["\\/bfnrt]" contained
 syn match   json5Escape    "\\u\x\{4}" contained
 
 " Syntax: Numbers {{{1
-syn match   json5Number    "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>"
-syn keyword json5Number    Infinity -Infinity
+syn match   json5Number    "[-+]\=\.\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>"
+syn match   json5Number    "[-+]\=0[xX]\x*"
+syn keyword json5Number    Infinity -Infinity NaN
 
 " Syntax: An integer part of 0 followed by other digits is not allowed.
 syn match   json5NumError  "-\=\<0\d\.\d*\>"


### PR DESCRIPTION
Various updates to json5Number:

- Added support for hexadecimal numbers
- Leading and trailing decimal points are handled correctly
- Added support for "NaN"
- "-Infinity" is handled correctly
- Moved json5Number above json5String to prevent interference
