### PR TITLE
Stylistic Updates

### DIFF
--- a/syntax/json5.vim
+++ b/syntax/json5.vim
@@ -12,14 +12,17 @@ syn match   json5Number    "[-+]\=0[xX]\x*"
 syn match   json5Number    "[-+]\=Infinity\|NaN"
 
 " An integer part of 0 followed by other digits is not allowed
-syn match   json5NumError  "-\=\<0\d\.\d*\>"
+syn match   json5NumError  "[-+]\=0\d\(\d\|\.\)*"
+
+" A hexadecimal number cannot have a fractional part
+syn match   json5NumError  "[-+]\=0x\x*\.\x*"
 
 " Strings
 syn region  json5String    start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=json5Escape,@Spell
 syn region  json5String    start=+'+  skip=+\\\\\|\\'+  end=+'+  contains=json5Escape,@Spell
 
 " Escape sequences
-syn match   json5Escape    "\\["\\/bfnrt]" contained
+syn match   json5Escape    "\\['\"\\bfnrtv]" contained
 syn match   json5Escape    "\\u\x\{4}" contained
 
 " Boolean

--- a/syntax/json5.vim
+++ b/syntax/json5.vim
@@ -1,47 +1,58 @@
-" Syntax setup {{{1
+" Modified from the original taken from https://github.com/gutenye/json5.vim
+
+" Syntax setup
 if exists('b:current_syntax') && b:current_syntax == 'json5'
   finish
 endif
 
-" Syntax: Numbers {{{1
-syn match json5Number    "[-+]\=\%(0\|[1-9]\d*\)\%(\.\d*\)\=\%([eE][-+]\=\d\+\)\="
-syn match json5Number    "[-+]\=\%(\.\d\+\)\%([eE][-+]\=\d\+\)\="
-syn match json5Number    "[-+]\=0[xX]\x*"
-syn match json5Number    "[-+]\=Infinity\|NaN"
+" Numbers
+syn match   json5Number    "[-+]\=\%(0\|[1-9]\d*\)\%(\.\d*\)\=\%([eE][-+]\=\d\+\)\="
+syn match   json5Number    "[-+]\=\%(\.\d\+\)\%([eE][-+]\=\d\+\)\="
+syn match   json5Number    "[-+]\=0[xX]\x*"
+syn match   json5Number    "[-+]\=Infinity\|NaN"
 
-" Syntax: An integer part of 0 followed by other digits is not allowed.
+" An integer part of 0 followed by other digits is not allowed
 syn match   json5NumError  "-\=\<0\d\.\d*\>"
 
-" Syntax: Strings {{{1
-syn region  json5String    start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=json5Escape
-syn region  json5String    start=+'+  skip=+\\\\\|\\'+  end=+'+  contains=json5Escape
+" Strings
+syn region  json5String    start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=json5Escape,@Spell
+syn region  json5String    start=+'+  skip=+\\\\\|\\'+  end=+'+  contains=json5Escape,@Spell
 
-" Syntax: Escape sequences
+" Escape sequences
 syn match   json5Escape    "\\["\\/bfnrt]" contained
 syn match   json5Escape    "\\u\x\{4}" contained
 
-" Syntax: Boolean {{{1
+" Boolean
 syn keyword json5Boolean   true false
 
-" Syntax: Null {{{1
+" Null
 syn keyword json5Null      null
 
-" Syntax: Braces {{{1
+" Delimiters and Operators
+syn match   json5Delimiter  ","
+syn match   json5Operator   ":"
+
+" Braces
 syn match   json5Braces	   "[{}\[\]]"
-syn match   json5ObjAssign /@\?\%(\I\|\$\)\%(\i\|\$\)*\s*\ze::\@!/
 
-" Syntax: Comment {{{1
-syn region  json5LineComment    start=+\/\/+ end=+$+ keepend
-syn region  json5LineComment    start=+^\s*\/\/+ skip=+\n\s*\/\/+ end=+$+ keepend fold
-syn region  json5Comment        start="/\*"  end="\*/" fold
+" Keys
+syn match   json5Key /@\?\%(\I\|\$\)\%(\i\|\$\)*\s*\ze::\@!/ contains=@Spell
+syn match   json5Key /"\([^"]\|\\"\)\{-}"\ze\s*:/ contains=json5Escape,@Spell
 
-" Define the default highlighting. {{{1
+" Comment
+syn region  json5LineComment    start=+\/\/+ end=+$+ keepend contains=@Spell
+syn region  json5LineComment    start=+^\s*\/\/+ skip=+\n\s*\/\/+ end=+$+ keepend fold contains=@Spell
+syn region  json5Comment        start="/\*"  end="\*/" fold contains=@Spell
+
+" Define the default highlighting
 hi def link json5String             String
-hi def link json5ObjAssign          Identifier
+hi def link json5Key                Identifier
 hi def link json5Escape             Special
 hi def link json5Number             Number
-hi def link json5Braces             Operator
-hi def link json5Null               Function
+hi def link json5Delimiter          Delimiter
+hi def link json5Operator           Operator
+hi def link json5Braces             Delimiter
+hi def link json5Null               Keyword
 hi def link json5Boolean            Boolean
 hi def link json5LineComment        Comment
 hi def link json5Comment            Comment
@@ -51,4 +62,3 @@ if !exists('b:current_syntax')
   let b:current_syntax = 'json5'
 endif
 
-" vim: fdm=marker


### PR DESCRIPTION
This should be run on top of PR #4 

Various stylistic changes:

- Added explicit "@Spell" dependencies
- Added commas and colons to delimiters and operators, respectively
- Changed "json5ObjAssign" to "json5Key"
- Included string-style keys in json5Key
- Changed braces to use the "Delimiter" style
- Changed "null" to use the "Keyword" style
- Removed the comment pragmas
- Added a header comment to give credit to the original
